### PR TITLE
Support `debug_swap` from Kernel 6.6

### DIFF
--- a/.github/workflows/upstream-equivalence.yml
+++ b/.github/workflows/upstream-equivalence.yml
@@ -23,7 +23,7 @@ jobs:
         sudo python3 -m pip install --user --require-hashes -r .github/workflows/upstream-equivalence-requirements.txt
 
     - name: Install Nix
-      uses: cachix/install-nix-action@6ed004b9ccb68dbc28e7c85bee15fa93dbd214ac # v22
+      uses: cachix/install-nix-action@6a9a9e84a173d90b3ffb42c5ddaf9ea033fad011 # v23
 
     - name: Download Firmware release
       id: download-firmware

--- a/.github/workflows/upstream-equivalence.yml
+++ b/.github/workflows/upstream-equivalence.yml
@@ -24,6 +24,9 @@ jobs:
 
     - name: Install Nix
       uses: cachix/install-nix-action@6a9a9e84a173d90b3ffb42c5ddaf9ea033fad011 # v23
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.9.2/install
+        nix_path: nixpkgs=channel:nixos-23.05
 
     - name: Download Firmware release
       id: download-firmware

--- a/.github/workflows/upstream-equivalence.yml
+++ b/.github/workflows/upstream-equivalence.yml
@@ -61,8 +61,8 @@ jobs:
 
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       with:
-        repository: edgelesssys/sev-snp-measure-go.git
-        ref: main
+        repository: virtee/sev-snp-measure-go.git
+        ref: ${{ github.ref_name }}
         path: sev-snp-measure-go
 
     - name: Run sev-snp-measure

--- a/e2e/upstream_test.go
+++ b/e2e/upstream_test.go
@@ -53,7 +53,8 @@ func TestCompatibility(t *testing.T) {
 		ovmfHash, err := guest.OVMFHash(ovmfObj)
 		require.NoError(err, "calculating OVMF hash: %s", err)
 
-		digest, err := guest.LaunchDigestFromOVMF(ovmfObj, entry.vcpus, ovmfHash)
+		// Documentation for guestFeatures value: https://github.com/virtee/sev-snp-measure/pull/32/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R126.
+		digest, err := guest.LaunchDigestFromOVMF(ovmfObj, 0x21, entry.vcpus, ovmfHash)
 		require.NoError(err, "calculating launch digest: %s", err)
 
 		assert.True(bytes.Equal(digest, entry.measurement), "expected hash %x, got %x", entry.measurement, digest)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgelesssys/sev-snp-measure-go
 go 1.20
 
 require (
-	github.com/google/uuid v1.3.0
+	github.com/google/uuid v1.3.1
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/guest/guest_test.go
+++ b/guest/guest_test.go
@@ -57,7 +57,7 @@ func TestLaunchDigestFromOVMF(t *testing.T) {
 			ovmfObj, err := ovmf.New(tc.ovmfPath)
 			require.NoError(err)
 
-			launchDigest, err := LaunchDigestFromOVMF(ovmfObj, tc.vcpuCount, hash)
+			launchDigest, err := LaunchDigestFromOVMF(ovmfObj, 0x1, tc.vcpuCount, hash)
 			if tc.wantErr {
 				assert.Error(err)
 			} else {
@@ -101,7 +101,7 @@ func TestLaunchDigestFromMetadataWrapper(t *testing.T) {
 			err = json.Unmarshal(data, &apiObject)
 			require.NoError(err)
 
-			launchDigest, err := LaunchDigestFromMetadataWrapper(apiObject, tc.vcpuCount)
+			launchDigest, err := LaunchDigestFromMetadataWrapper(apiObject, 0x1, tc.vcpuCount)
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/vmsa/vmsa.go
+++ b/vmsa/vmsa.go
@@ -145,7 +145,7 @@ type SevEsSaveArea struct {
 	Unused           [2448]uint8
 }
 
-func BuildSaveArea(eip uint32, vcpuSig uint64, vmmType vmmtypes.VMMType) (SevEsSaveArea, error) {
+func BuildSaveArea(eip uint32, guestFeatures uint64, vcpuSig uint64, vmmType vmmtypes.VMMType) (SevEsSaveArea, error) {
 	var csFlags, ssFlags, trFlags uint16
 	var rdx uint64
 	switch vmmType {
@@ -185,7 +185,7 @@ func BuildSaveArea(eip uint32, vcpuSig uint64, vmmType vmmtypes.VMMType) (SevEsS
 		Rip:         uint64(eip & 0xffff),
 		GPat:        0x7040600070406, // PAT MSR: See AMD APM Vol 2, Section A.3.
 		Rdx:         rdx,
-		SevFeatures: 0x1, // Make this configurable if we want to support other modes than SEV-SNP.
+		SevFeatures: guestFeatures, // Documentation: https://github.com/virtee/sev-snp-measure/pull/32/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R125.
 		Xcr0:        0x1,
 	}, nil
 }
@@ -195,14 +195,14 @@ type VMSA struct {
 	ApSaveArea  SevEsSaveArea
 }
 
-func New(apEip uint32, vcpuSig uint64, vmmType vmmtypes.VMMType) (VMSA, error) {
-	bspSaveArea, err := BuildSaveArea(BspEIP, vcpuSig, vmmType)
+func New(apEip uint32, guestFeatures uint64, vcpuSig uint64, vmmType vmmtypes.VMMType) (VMSA, error) {
+	bspSaveArea, err := BuildSaveArea(BspEIP, guestFeatures, vcpuSig, vmmType)
 	if err != nil {
 		return VMSA{}, err
 	}
 	var apSaveArea SevEsSaveArea
 	if apEip != 0 {
-		apSaveArea, err = BuildSaveArea(apEip, vcpuSig, vmmType)
+		apSaveArea, err = BuildSaveArea(apEip, guestFeatures, vcpuSig, vmmType)
 		if err != nil {
 			return VMSA{}, err
 		}


### PR DESCRIPTION
There was an [upstream PR](https://github.com/virtee/sev-snp-measure/pull/32) that changed the default measurements generated by sev-snp-measure. This PR ports the upstream change. 
The actual fix is in commit [b0e59fbc186b4c9c7199f9fcbfb595c8ecfe6649](https://github.com/virtee/sev-snp-measure-go/commit/b0e59fbc186b4c9c7199f9fcbfb595c8ecfe6649).

Taking the opportunity to also add some dependency updates and readme additions.

[CI run](https://github.com/virtee/sev-snp-measure-go/actions/runs/7800680193).
