### PR TITLE
golang: update module name and golang imports to use virtee packages

### DIFF
--- a/e2e/upstream_test.go
+++ b/e2e/upstream_test.go
@@ -21,9 +21,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/edgelesssys/sev-snp-measure-go/guest"
-	"github.com/edgelesssys/sev-snp-measure-go/ovmf"
-	"github.com/edgelesssys/sev-snp-measure-go/vmmtypes"
+	"github.com/virtee/sev-snp-measure-go/guest"
+	"github.com/virtee/sev-snp-measure-go/ovmf"
+	"github.com/virtee/sev-snp-measure-go/vmmtypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/edgelesssys/sev-snp-measure-go
+module github.com/virtee/sev-snp-measure-go
 
 go 1.20
 

--- a/guest/guest.go
+++ b/guest/guest.go
@@ -11,11 +11,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/edgelesssys/sev-snp-measure-go/cpuid"
-	"github.com/edgelesssys/sev-snp-measure-go/gctx"
-	"github.com/edgelesssys/sev-snp-measure-go/ovmf"
-	"github.com/edgelesssys/sev-snp-measure-go/vmmtypes"
-	"github.com/edgelesssys/sev-snp-measure-go/vmsa"
+	"github.com/virtee/sev-snp-measure-go/cpuid"
+	"github.com/virtee/sev-snp-measure-go/gctx"
+	"github.com/virtee/sev-snp-measure-go/ovmf"
+	"github.com/virtee/sev-snp-measure-go/vmmtypes"
+	"github.com/virtee/sev-snp-measure-go/vmsa"
 )
 
 // LaunchDigestFromMetadataWrapper calculates a launch digest from a MetadataWrapper object.

--- a/guest/guest_test.go
+++ b/guest/guest_test.go
@@ -15,8 +15,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/edgelesssys/sev-snp-measure-go/ovmf"
-	"github.com/edgelesssys/sev-snp-measure-go/vmmtypes"
+	"github.com/virtee/sev-snp-measure-go/ovmf"
+	"github.com/virtee/sev-snp-measure-go/vmmtypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/sevsnpmeasure/cmd/parse.go
+++ b/sevsnpmeasure/cmd/parse.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/edgelesssys/sev-snp-measure-go/guest"
-	"github.com/edgelesssys/sev-snp-measure-go/ovmf"
+	"github.com/virtee/sev-snp-measure-go/guest"
+	"github.com/virtee/sev-snp-measure-go/ovmf"
 	"github.com/spf13/cobra"
 )
 

--- a/sevsnpmeasure/main.go
+++ b/sevsnpmeasure/main.go
@@ -9,7 +9,7 @@ package main
 import (
 	"os"
 
-	"github.com/edgelesssys/sev-snp-measure-go/sevsnpmeasure/cmd"
+	"github.com/virtee/sev-snp-measure-go/sevsnpmeasure/cmd"
 )
 
 func main() {

--- a/vmsa/vmsa.go
+++ b/vmsa/vmsa.go
@@ -17,7 +17,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/edgelesssys/sev-snp-measure-go/vmmtypes"
+	"github.com/virtee/sev-snp-measure-go/vmmtypes"
 )
 
 const (


### PR DESCRIPTION
go.mod still refers to the module name as
"github.com/edgelesssys/sev-snp-measure-go". This causes an error when adding this module as a dependency from another project. As such, we need to update the module's name to "github.com/virtee/sev-snp-measure-go".

While we are at it, we could also update the Golang imports to refer to the virtee repo