### PR TITLE
ci: add linter and enable e2e test on all PRs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,28 @@
+name: "Test: static-analyis"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+        with:
+          go-version: stable
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
+        with:
+          version: v1.62.2

--- a/.github/workflows/upstream-equivalence.yml
+++ b/.github/workflows/upstream-equivalence.yml
@@ -1,4 +1,4 @@
-name: Upstream Equivalence
+name: "Test: upstream Equivalence"
 
 on:
   workflow_dispatch:
@@ -7,15 +7,21 @@ on:
     # We want to learn somewhat quickly about changes in upstream.
     # But we do not expect changes on a regular basis.
     - cron: '0 22 * * 1,3,5'
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   run:
     runs-on: ubuntu-22.04
     steps:
-    - name: Checkout repository
+    - name: Checkout sev-snp-measure-go
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       with:
         ref: ${{ github.head_ref }}
+
     - name: Install necessary tools
       run: |
         sudo apt-get update
@@ -52,17 +58,18 @@ jobs:
         ovmfPath=$(realpath result/ovmf_img.fd)
         echo "ovmfPath=${ovmfPath}" | tee -a "$GITHUB_OUTPUT"
 
-
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+    - name: Checkout sev-snp-measure
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       with:
         repository: virtee/sev-snp-measure.git
         ref: main
         path: sev-snp-measure
 
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+    - name: Checkout sev-snp-measure-go in subdir
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       with:
         repository: virtee/sev-snp-measure-go.git
-        ref: ${{ github.ref_name }}
+        ref: ${{ github.head_ref }}
         path: sev-snp-measure-go
 
     - name: Run sev-snp-measure

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    // Use gofumpt as formatter.
+    "gopls": {
+        "formatting.gofumpt": true,
+        "build.buildFlags": ["-tags", "e2e"]
+    },
+    // Use golangci-lint as linter. Make sure you've installed it.
+    "go.lintTool": "golangci-lint",
+    "go.lintFlags": [
+        "--fast"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Run linter:
 golangci-lint run ./...
 ```
 
+# Style
+
+Please make sure that the content of files follows this order (sorted from top to bottom):
+- Constants and variables
+- Exported functions
+- Exported types followed by their new funcs, exported methods, and unexported methods, i.e.
+- Unexported functions
+- Unexported types and their methods
+
 # Used by
 
 This tool was originally developed for [Constellation](https://github.com/edgelesssys/constellation) to verify launch measurements on AWS's SNP instances.

--- a/guest/guest.go
+++ b/guest/guest.go
@@ -50,7 +50,7 @@ func launchDigest(metadata []ovmf.MetadataSection, resetEIP uint32, guestFeature
 
 	vcpu_sig, ok := cpuid.CpuSigs[vcpu_type]
 	if !ok {
-		fmt.Println("Failed to find VCPU signature for %s", vcpu_type)
+		fmt.Printf("Failed to find VCPU signature for vcpu_type %s\n", vcpu_type)
 		vcpu_sig = 0
 	}
 

--- a/ovmf/ovmf.go
+++ b/ovmf/ovmf.go
@@ -197,7 +197,7 @@ func (m *MetadataWrapper) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"MetadataItems": m.MetadataItems,
 		"ResetEIP":      fmt.Sprintf("0x%x", m.ResetEIP),
-		"OVMFHash":      fmt.Sprintf("%s", hex.EncodeToString(m.OVMFHash)),
+		"OVMFHash":      hex.EncodeToString(m.OVMFHash),
 	})
 }
 


### PR DESCRIPTION
Currently the CI is not running the linter. It also only runs the equivalence test on a schedule. Both workflows should be successful for any contribution.

Also mention order of elements style in the readme.