### PR TITLE
Upstream/cpuspec turin

### DIFF
--- a/cpuid/cpuid.go
+++ b/cpuid/cpuid.go
@@ -55,6 +55,7 @@ var CpuSigs = map[string]int{
 	"EPYC-Genoa":    cpuSig(25, 17, 0),
 	"EPYC-Genoa-v1": cpuSig(25, 17, 0),
 	"EPYC-Genoa-v2": cpuSig(25, 17, 0),
+	"EPYC-Turin":    cpuSig(26, 0, 0),
 }
 
 type CpuSpec struct {

--- a/cpuid/cpuid.go
+++ b/cpuid/cpuid.go
@@ -7,6 +7,14 @@ SPDX-License-Identifier: Apache-2.0
 
 package cpuid
 
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrSigInsufficientOptions = errors.New("specify at least one of signature, model or FMS")
+var ErrSigMultipleCpuOptions = errors.New("specify only one of signature, model or FMS")
+
 func cpuSig(family int, model int, stepping int) int {
 	var familyLow, familyHigh, modelLow, modelHigh, steppingLow int
 
@@ -47,4 +55,70 @@ var CpuSigs = map[string]int{
 	"EPYC-Genoa":    cpuSig(25, 17, 0),
 	"EPYC-Genoa-v1": cpuSig(25, 17, 0),
 	"EPYC-Genoa-v2": cpuSig(25, 17, 0),
+}
+
+type CpuSpec struct {
+	CpuSignature *uint32
+	QemuCpuModel *string
+	CpuFamily    *uint32
+	CpuModel     *uint32
+	CpuStepping  *uint32
+}
+
+func CpuSignature(sig uint32) CpuSpec {
+	return CpuSpec{CpuSignature: &sig}
+}
+
+func QemuCpuModel(model string) CpuSpec {
+	return CpuSpec{QemuCpuModel: &model}
+}
+
+func CpuFMS(family uint32, model uint32, stepping uint32) CpuSpec {
+	return CpuSpec{CpuFamily: &family, CpuModel: &model, CpuStepping: &stepping}
+}
+
+func GetCpuSig(spec CpuSpec) (int, error) {
+	var (
+		signature                int
+		suppliedSpecs            int
+		hasSig, hasModel, hasFMS bool
+	)
+
+	if hasSig = spec.CpuSignature != nil; hasSig {
+		suppliedSpecs++
+	}
+
+	if hasModel = spec.QemuCpuModel != nil; hasModel {
+		suppliedSpecs++
+	}
+
+	if hasFMS = spec.CpuFamily != nil; hasFMS {
+		suppliedSpecs++
+	}
+
+	if suppliedSpecs > 1 {
+		return 0, ErrSigMultipleCpuOptions
+	}
+
+	if suppliedSpecs == 0 {
+		return 0, ErrSigInsufficientOptions
+	}
+
+	if hasSig {
+		signature = int(*spec.CpuSignature)
+	}
+
+	if hasModel {
+		var ok bool
+		signature, ok = CpuSigs[*spec.QemuCpuModel]
+		if !ok {
+			return 0, fmt.Errorf("unknown model %v", *spec.QemuCpuModel)
+		}
+	}
+
+	if hasFMS {
+		signature = cpuSig(int(*spec.CpuFamily), int(*spec.CpuModel), int(*spec.CpuStepping))
+	}
+
+	return signature, nil
 }

--- a/guest/guest.go
+++ b/guest/guest.go
@@ -19,17 +19,28 @@ import (
 )
 
 // LaunchDigestFromMetadataWrapper calculates a launch digest from a MetadataWrapper object.
-func LaunchDigestFromMetadataWrapper(wrapper ovmf.MetadataWrapper, guestFeatures uint64, vcpuCount int, vmmtype vmmtypes.VMMType, vcpu_type string) ([]byte, error) {
-	return launchDigest(wrapper.MetadataItems, wrapper.ResetEIP, guestFeatures, vcpuCount, wrapper.OVMFHash, vmmtype, vcpu_type)
+func LaunchDigestFromMetadataWrapper(wrapper ovmf.MetadataWrapper, guestFeatures uint64, vcpuCount int, vmmtype vmmtypes.VMMType, spec cpuid.CpuSpec) ([]byte, error) {
+	vcpuSig, err := cpuid.GetCpuSig(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return launchDigest(wrapper.MetadataItems, wrapper.ResetEIP, guestFeatures, vcpuCount, wrapper.OVMFHash, vmmtype, vcpuSig)
 }
 
 // LaunchDigestFromOVMF calculates a launch digest from an OVMF object and an ovmfHash.
-func LaunchDigestFromOVMF(ovmfObj ovmf.OVMF, guestFeatures uint64, vcpuCount int, ovmfHash []byte, vmmtype vmmtypes.VMMType, vcpu_type string) ([]byte, error) {
+func LaunchDigestFromOVMF(ovmfObj ovmf.OVMF, guestFeatures uint64, vcpuCount int, ovmfHash []byte, vmmtype vmmtypes.VMMType, spec cpuid.CpuSpec) ([]byte, error) {
 	resetEIP, err := ovmfObj.SevESResetEIP()
 	if err != nil {
 		return nil, fmt.Errorf("getting reset EIP: %w", err)
 	}
-	return launchDigest(ovmfObj.MetadataItems(), resetEIP, guestFeatures, vcpuCount, ovmfHash, vmmtype, vcpu_type)
+
+	vcpuSig, err := cpuid.GetCpuSig(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return launchDigest(ovmfObj.MetadataItems(), resetEIP, guestFeatures, vcpuCount, ovmfHash, vmmtype, vcpuSig)
 }
 
 func OVMFHash(ovmfObj ovmf.OVMF) ([]byte, error) {
@@ -41,17 +52,11 @@ func OVMFHash(ovmfObj ovmf.OVMF) ([]byte, error) {
 }
 
 // launchDigest calculates the launch digest from metadata and ovmfHash for a SNP guest.
-func launchDigest(metadata []ovmf.MetadataSection, resetEIP uint32, guestFeatures uint64, vcpuCount int, ovmfHash []byte, vmmtype vmmtypes.VMMType, vcpu_type string) ([]byte, error) {
+func launchDigest(metadata []ovmf.MetadataSection, resetEIP uint32, guestFeatures uint64, vcpuCount int, ovmfHash []byte, vmmtype vmmtypes.VMMType, vcpu_sig int) ([]byte, error) {
 	guestCtx := gctx.New(ovmfHash)
 
 	if err := snpUpdateMetadataPages(guestCtx, metadata, vmmtype); err != nil {
 		return nil, fmt.Errorf("updating metadata pages: %w", err)
-	}
-
-	vcpu_sig, ok := cpuid.CpuSigs[vcpu_type]
-	if !ok {
-		fmt.Printf("Failed to find VCPU signature for vcpu_type %s\n", vcpu_type)
-		vcpu_sig = 0
 	}
 
 	vmsaObj, err := vmsa.New(resetEIP, guestFeatures, uint64(vcpu_sig), vmmtype)


### PR DESCRIPTION
Hi,

This PR does the following two functions:

- Allow specification of CPU in the LaunchDigest* methods. CPU spec could be QEMU cpu model, vcpu signature or it could be individual CPU spec. [sev-snp-measure](https://github.com/virtee/sev-snp-measure) does this already (lines 56 - 62 in this file: https://github.com/virtee/sev-snp-measure/blob/main/sevsnpmeasure/cli.py#L56)
- Add QEMU's EPYC-Turin model to CpuSigs database