### PR TITLE
Add support for GCE measurement derivation

### DIFF
--- a/e2e/upstream_test.go
+++ b/e2e/upstream_test.go
@@ -15,17 +15,18 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/virtee/sev-snp-measure-go/guest"
 	"github.com/virtee/sev-snp-measure-go/ovmf"
 	"github.com/virtee/sev-snp-measure-go/vmmtypes"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -48,8 +49,8 @@ func TestCompatibility(t *testing.T) {
 	guestFeatures, err := strconv.ParseUint(*guestFeaturesStr, 0, 64)
 	require.NoError(err, "parsing guest features: %s", err)
 
-	vmmType := parseVMMType(*vmmTypeStr)
-	require.NotEqual(vmmtypes.VMMType(-1), vmmType, "invalid vmm type: %s", *vmmTypeStr)
+	vmmType, err := parseVMMType(*vmmTypeStr)
+	require.NoError(err, "parsing vmm type: %s", err)
 
 	values, err := os.ReadFile(*valuesPath)
 	require.NoError(err, "reading values file: %s", err)
@@ -96,15 +97,15 @@ func (e *expectedValues) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func parseVMMType(vmmTypeStr string) vmmtypes.VMMType {
+func parseVMMType(vmmTypeStr string) (vmmtypes.VMMType, error) {
 	switch vmmTypeStr {
 	case "ec2":
-		return vmmtypes.EC2
+		return vmmtypes.EC2, nil
 	case "gce":
-		return vmmtypes.GCE
+		return vmmtypes.GCE, nil
 	case "qemu":
-		return vmmtypes.QEMU
+		return vmmtypes.QEMU, nil
 	default:
-		return -1
+		return 0, errors.New("unsupported vmm type")
 	}
 }

--- a/e2e/upstream_test.go
+++ b/e2e/upstream_test.go
@@ -31,6 +31,9 @@ import (
 var (
 	valuesPath = flag.String("expected-values", "", "Path to json file containing hashes to compare against.")
 	binaryPath = flag.String("ovmf", "", "Path to OVMF binary that should be measured.")
+	// Documentation for guestFeaturesStr value: https://github.com/virtee/sev-snp-measure/pull/32/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R126.
+	guestFeaturesStr = flag.String("guest-features", "0x21", "Hex string representing the guest features to use for the measurement.")
+	vmmTypeStr       = flag.String("vmm-type", "ec2", "Corresponding VMM type for the expected values. Supported values for this flag are: ec2 (default), gce, and qemu.")
 )
 
 func TestCompatibility(t *testing.T) {
@@ -39,6 +42,14 @@ func TestCompatibility(t *testing.T) {
 
 	require.NotEmpty(*valuesPath, "expected-values flag must be set")
 	require.NotEmpty(*binaryPath, "ovmf flag must be set")
+	require.NotEmpty(*guestFeaturesStr, "guest-features cannot be empty")
+	require.NotEmpty(*vmmTypeStr, "vmm-type flag cannot be empty")
+
+	guestFeatures, err := strconv.ParseUint(*guestFeaturesStr, 0, 64)
+	require.NoError(err, "parsing guest features: %s", err)
+
+	vmmType := parseVMMType(*vmmTypeStr)
+	require.NotEqual(vmmtypes.VMMType(-1), vmmType, "invalid vmm type: %s", *vmmTypeStr)
 
 	values, err := os.ReadFile(*valuesPath)
 	require.NoError(err, "reading values file: %s", err)
@@ -54,8 +65,7 @@ func TestCompatibility(t *testing.T) {
 		ovmfHash, err := guest.OVMFHash(ovmfObj)
 		require.NoError(err, "calculating OVMF hash: %s", err)
 
-		// Documentation for guestFeatures value: https://github.com/virtee/sev-snp-measure/pull/32/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R126.
-		digest, err := guest.LaunchDigestFromOVMF(ovmfObj, 0x21, entry.vcpus, ovmfHash, vmmtypes.EC2, "")
+		digest, err := guest.LaunchDigestFromOVMF(ovmfObj, guestFeatures, entry.vcpus, ovmfHash, vmmType, "")
 		require.NoError(err, "calculating launch digest: %s", err)
 
 		assert.True(bytes.Equal(digest, entry.measurement), "expected hash %x, got %x", entry.measurement, digest)
@@ -84,4 +94,17 @@ func (e *expectedValues) UnmarshalJSON(data []byte) error {
 	e.vcpus = int(vcpus)
 	e.measurement = measurement
 	return nil
+}
+
+func parseVMMType(vmmTypeStr string) vmmtypes.VMMType {
+	switch vmmTypeStr {
+	case "ec2":
+		return vmmtypes.EC2
+	case "gce":
+		return vmmtypes.GCE
+	case "qemu":
+		return vmmtypes.QEMU
+	default:
+		return -1
+	}
 }

--- a/gctx/gctx.go
+++ b/gctx/gctx.go
@@ -124,15 +124,16 @@ func (g *GCTX) UpdateZeroPages(gpa uint64, lengthBytes int) error {
 	return nil
 }
 
-func (g *GCTX) UpdateUnmeasuredPages(gpa uint64, lenghtBytes int) error {
-	if lenghtBytes%PAGE_SIZE != 0 {
+// UpdateUnmeasuredPages extends the current launch digest with the hash of a page containing only zeros. Pagetype is set to 0x04.
+func (g *GCTX) UpdateUnmeasuredPages(gpa uint64, lengthBytes int) error {
+	if lengthBytes%PAGE_SIZE != 0 {
 		return errors.New("invalid length")
 	}
 
 	offset := 0
-	for offset < lenghtBytes {
+	for offset < lengthBytes {
 		if err := g.update(0x04, gpa+uint64(offset), bytes.Repeat([]byte{0x00}, LD_SIZE)); err != nil {
-			return err
+			return fmt.Errorf("updating guest context: %w", err)
 		}
 		offset += PAGE_SIZE
 	}

--- a/gctx/gctx.go
+++ b/gctx/gctx.go
@@ -124,6 +124,21 @@ func (g *GCTX) UpdateZeroPages(gpa uint64, lengthBytes int) error {
 	return nil
 }
 
+func (g *GCTX) UpdateUnmeasuredPages(gpa uint64, lenghtBytes int) error {
+	if lenghtBytes%PAGE_SIZE != 0 {
+		return errors.New("invalid length")
+	}
+
+	offset := 0
+	for offset < lenghtBytes {
+		if err := g.update(0x04, gpa+uint64(offset), bytes.Repeat([]byte{0x00}, LD_SIZE)); err != nil {
+			return err
+		}
+		offset += PAGE_SIZE
+	}
+	return nil
+}
+
 // UpdateSecretsPage extends the current launch digest with the hash of a page containing only zeros. Pagetype is set to 0x05.
 func (g *GCTX) UpdateSecretsPage(gpa uint64) error {
 	return g.update(0x05, gpa, bytes.Repeat([]byte{0x00}, LD_SIZE))

--- a/guest/guest.go
+++ b/guest/guest.go
@@ -48,10 +48,10 @@ func launchDigest(metadata []ovmf.MetadataSection, resetEIP uint32, guestFeature
 		return nil, fmt.Errorf("updating metadata pages: %w", err)
 	}
 
-	// Allow empty vcpu_type for EC2 for backwards compatibility.
+	// Allow empty vcpu_type for EC2 and GCE for backwards compatibility.
 	// vcpuSig is ignored in BuildSaveArea.
 	// TODO: once the project has a release pipeline consider a major release to break the API.
-	if vmmtype == vmmtypes.EC2 {
+	if vmmtype == vmmtypes.EC2 || vmmtype == vmmtypes.GCE {
 		vcpu_type = "EPYC"
 	}
 
@@ -86,7 +86,17 @@ func snpUpdateMetadataPages(gctx *gctx.GCTX, metadata []ovmf.MetadataSection, vm
 			return fmt.Errorf("getting sectionType: %w", err)
 		}
 		switch st {
-		case ovmf.SNPSECMEM, ovmf.SVSM_CAA:
+		case ovmf.SNPSECMEM:
+			if vmmType == vmmtypes.GCE {
+				if err := gctx.UpdateUnmeasuredPages(uint64(desc.GPA), int(desc.Size)); err != nil {
+					return fmt.Errorf("updating unmeasured pages: %w", err)
+				}
+			} else {
+				if err := gctx.UpdateZeroPages(uint64(desc.GPA), int(desc.Size)); err != nil {
+					return fmt.Errorf("updating zero pages: %w", err)
+				}
+			}
+		case ovmf.SVSM_CAA:
 			if err := gctx.UpdateZeroPages(uint64(desc.GPA), int(desc.Size)); err != nil {
 				return fmt.Errorf("updating zero pages: %w", err)
 			}

--- a/guest/guest_test.go
+++ b/guest/guest_test.go
@@ -37,6 +37,10 @@ func TestLaunchDigestCPUSignatureHandling(t *testing.T) {
 			vmmType:  vmmtypes.EC2,
 			vcpuType: "",
 		},
+		"gce ignores empty vcpu type": {
+			vmmType:  vmmtypes.GCE,
+			vcpuType: "",
+		},
 		"qemu rejects unknown vcpu type": {
 			vmmType:           vmmtypes.QEMU,
 			vcpuType:          "",
@@ -62,43 +66,43 @@ func TestLaunchDigestFromOVMF(t *testing.T) {
 		ovmfPath     string
 		ovmfHash     string
 		vcpuCount    int
+		vmmType      vmmtypes.VMMType
 		expectedHash string
 		wantErr      bool
-		vmmType      vmmtypes.VMMType
 	}{
 		"success bin 1": {
 			ovmfPath: "testdata/ovmf_img_1.bin",
 			// Created by running: ./sev-snp-measure.py --mode snp:ovmf-hash --ovmf ovmf_img_1.fd
 			ovmfHash:  "a58211791a556a630a4319dc9e2ea96cc0e9784dd9f20a4fadf81b26c98d163fcdcb6703884bbbb80d7b1de45b3d84d0",
 			vcpuCount: 2,
+			vmmType:   vmmtypes.EC2,
 			// Created by running: ./sev-snp-measure.py --mode snp --vcpus 2 --ovmf ovmf_img_1.fd --vmm-type ec2 --snp-ovmf-hash a58211791a556a630a4319dc9e2ea96cc0e9784dd9f20a4fadf81b26c98d163fcdcb6703884bbbb80d7b1de45b3d84d0
 			expectedHash: "4c6e33087d08fa770259484dddbef367086a15c3e2cf10038dc97229d39c942671c2e22b300178f8de594a3f2fa59303",
-			vmmType:      vmmtypes.EC2,
 		},
 		"success bin 2": {
 			ovmfPath: "testdata/ovmf_img_2.bin",
 			// Created by running: ./sev-snp-measure.py --mode snp:ovmf-hash --ovmf ovmf_img_2.fd
 			ovmfHash:     "2027a27bb9f7acfd280e4c7bd68a73973b94bf0756e5b282e004b9395f597b8d0eb4defa7d8f6549375aa4d2b146f0f3",
 			vcpuCount:    2,
-			expectedHash: "c2c84b9364fc9f0f54b04534768c860c6e0e386ad98b96e8b98eca46ac8971d05c531ba48373f054c880cfd1f4a0a84e",
 			vmmType:      vmmtypes.EC2,
+			expectedHash: "c2c84b9364fc9f0f54b04534768c860c6e0e386ad98b96e8b98eca46ac8971d05c531ba48373f054c880cfd1f4a0a84e",
 		},
 		"success bin 3": {
 			ovmfPath: "testdata/ovmf_img_1.bin",
 			// Created by running: ./sev-snp-measure.py --mode snp:ovmf-hash --ovmf ovmf_img_1.fd
 			ovmfHash:  "a58211791a556a630a4319dc9e2ea96cc0e9784dd9f20a4fadf81b26c98d163fcdcb6703884bbbb80d7b1de45b3d84d0",
 			vcpuCount: 2,
+			vmmType:   vmmtypes.GCE,
 			// Created by running: ./sev-snp-measure.py --mode snp --vcpus 2 --ovmf ovmf_img_1.fd --vmm-type gce --snp-ovmf-hash a58211791a556a630a4319dc9e2ea96cc0e9784dd9f20a4fadf81b26c98d163fcdcb6703884bbbb80d7b1de45b3d84d0
 			expectedHash: "92dd082c6f938452733ef95413d5b023f4a30b249ef5e65c96f090f84c96419004636f5289aa7de3e7948625c64fa67c",
-			vmmType:      vmmtypes.GCE,
 		},
 		"success bin 4": {
 			ovmfPath: "testdata/ovmf_img_2.bin",
 			// Created by running: ./sev-snp-measure.py --mode snp:ovmf-hash --ovmf ovmf_img_2.fd
 			ovmfHash:     "2027a27bb9f7acfd280e4c7bd68a73973b94bf0756e5b282e004b9395f597b8d0eb4defa7d8f6549375aa4d2b146f0f3",
 			vcpuCount:    2,
-			expectedHash: "d0a87fc891933399c54853b455aef5dd348db04465cf726d891b2f5b3f95cd85f42d47236acde9cb29acc3b154d05ef8",
 			vmmType:      vmmtypes.GCE,
+			expectedHash: "d0a87fc891933399c54853b455aef5dd348db04465cf726d891b2f5b3f95cd85f42d47236acde9cb29acc3b154d05ef8",
 		},
 	}
 
@@ -130,18 +134,33 @@ func TestLaunchDigestFromMetadataWrapper(t *testing.T) {
 	testCases := map[string]struct {
 		apiObjectPath  string
 		vcpuCount      int
+		vmmType        vmmtypes.VMMType
 		expectedDigest string
 		wantErr        bool
 	}{
 		"success bin 1": {
 			apiObjectPath:  "testdata/ovmf_img_1.json",
 			vcpuCount:      2,
+			vmmType:        vmmtypes.EC2,
 			expectedDigest: "4c6e33087d08fa770259484dddbef367086a15c3e2cf10038dc97229d39c942671c2e22b300178f8de594a3f2fa59303",
 		},
 		"success bin 2": {
 			apiObjectPath:  "testdata/ovmf_img_2.json",
 			vcpuCount:      2,
+			vmmType:        vmmtypes.EC2,
 			expectedDigest: "c2c84b9364fc9f0f54b04534768c860c6e0e386ad98b96e8b98eca46ac8971d05c531ba48373f054c880cfd1f4a0a84e",
+		},
+		"success bin 3": {
+			apiObjectPath:  "testdata/ovmf_img_1.json",
+			vcpuCount:      2,
+			vmmType:        vmmtypes.GCE,
+			expectedDigest: "92dd082c6f938452733ef95413d5b023f4a30b249ef5e65c96f090f84c96419004636f5289aa7de3e7948625c64fa67c",
+		},
+		"success bin 4": {
+			apiObjectPath:  "testdata/ovmf_img_2.json",
+			vcpuCount:      2,
+			vmmType:        vmmtypes.GCE,
+			expectedDigest: "d0a87fc891933399c54853b455aef5dd348db04465cf726d891b2f5b3f95cd85f42d47236acde9cb29acc3b154d05ef8",
 		},
 	}
 
@@ -157,7 +176,7 @@ func TestLaunchDigestFromMetadataWrapper(t *testing.T) {
 			err = json.Unmarshal(data, &apiObject)
 			require.NoError(err)
 
-			launchDigest, err := LaunchDigestFromMetadataWrapper(apiObject, 0x1, tc.vcpuCount, vmmtypes.EC2, "")
+			launchDigest, err := LaunchDigestFromMetadataWrapper(apiObject, 0x1, tc.vcpuCount, tc.vmmType, "")
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/guest/guest_test.go
+++ b/guest/guest_test.go
@@ -64,6 +64,7 @@ func TestLaunchDigestFromOVMF(t *testing.T) {
 		vcpuCount    int
 		expectedHash string
 		wantErr      bool
+		vmmType      vmmtypes.VMMType
 	}{
 		"success bin 1": {
 			ovmfPath: "testdata/ovmf_img_1.bin",
@@ -72,6 +73,7 @@ func TestLaunchDigestFromOVMF(t *testing.T) {
 			vcpuCount: 2,
 			// Created by running: ./sev-snp-measure.py --mode snp --vcpus 2 --ovmf ovmf_img_1.fd --vmm-type ec2 --snp-ovmf-hash a58211791a556a630a4319dc9e2ea96cc0e9784dd9f20a4fadf81b26c98d163fcdcb6703884bbbb80d7b1de45b3d84d0
 			expectedHash: "4c6e33087d08fa770259484dddbef367086a15c3e2cf10038dc97229d39c942671c2e22b300178f8de594a3f2fa59303",
+			vmmType:      vmmtypes.EC2,
 		},
 		"success bin 2": {
 			ovmfPath: "testdata/ovmf_img_2.bin",
@@ -79,6 +81,24 @@ func TestLaunchDigestFromOVMF(t *testing.T) {
 			ovmfHash:     "2027a27bb9f7acfd280e4c7bd68a73973b94bf0756e5b282e004b9395f597b8d0eb4defa7d8f6549375aa4d2b146f0f3",
 			vcpuCount:    2,
 			expectedHash: "c2c84b9364fc9f0f54b04534768c860c6e0e386ad98b96e8b98eca46ac8971d05c531ba48373f054c880cfd1f4a0a84e",
+			vmmType:      vmmtypes.EC2,
+		},
+		"success bin 3": {
+			ovmfPath: "testdata/ovmf_img_1.bin",
+			// Created by running: ./sev-snp-measure.py --mode snp:ovmf-hash --ovmf ovmf_img_1.fd
+			ovmfHash:  "a58211791a556a630a4319dc9e2ea96cc0e9784dd9f20a4fadf81b26c98d163fcdcb6703884bbbb80d7b1de45b3d84d0",
+			vcpuCount: 2,
+			// Created by running: ./sev-snp-measure.py --mode snp --vcpus 2 --ovmf ovmf_img_1.fd --vmm-type gce --snp-ovmf-hash a58211791a556a630a4319dc9e2ea96cc0e9784dd9f20a4fadf81b26c98d163fcdcb6703884bbbb80d7b1de45b3d84d0
+			expectedHash: "92dd082c6f938452733ef95413d5b023f4a30b249ef5e65c96f090f84c96419004636f5289aa7de3e7948625c64fa67c",
+			vmmType:      vmmtypes.GCE,
+		},
+		"success bin 4": {
+			ovmfPath: "testdata/ovmf_img_2.bin",
+			// Created by running: ./sev-snp-measure.py --mode snp:ovmf-hash --ovmf ovmf_img_2.fd
+			ovmfHash:     "2027a27bb9f7acfd280e4c7bd68a73973b94bf0756e5b282e004b9395f597b8d0eb4defa7d8f6549375aa4d2b146f0f3",
+			vcpuCount:    2,
+			expectedHash: "d0a87fc891933399c54853b455aef5dd348db04465cf726d891b2f5b3f95cd85f42d47236acde9cb29acc3b154d05ef8",
+			vmmType:      vmmtypes.GCE,
 		},
 	}
 
@@ -93,7 +113,7 @@ func TestLaunchDigestFromOVMF(t *testing.T) {
 			ovmfObj, err := ovmf.New(tc.ovmfPath)
 			require.NoError(err)
 
-			launchDigest, err := LaunchDigestFromOVMF(ovmfObj, 0x1, tc.vcpuCount, hash, vmmtypes.EC2, "")
+			launchDigest, err := LaunchDigestFromOVMF(ovmfObj, 0x1, tc.vcpuCount, hash, tc.vmmType, "")
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/vmmtypes/vmmtypes.go
+++ b/vmmtypes/vmmtypes.go
@@ -12,4 +12,5 @@ type VMMType int
 const (
 	QEMU VMMType = iota
 	EC2
+	GCE
 )

--- a/vmsa/vmsa.go
+++ b/vmsa/vmsa.go
@@ -150,6 +150,7 @@ type SevEsSaveArea struct {
 func BuildSaveArea(eip uint32, guestFeatures uint64, vcpuSig uint64, vmmType vmmtypes.VMMType) (SevEsSaveArea, error) {
 	var csFlags, ssFlags, trFlags, fcw uint16
 	var rdx uint64
+	var gpat uint64 = 0x7040600070406 // PAT MSR: See AMD APM Vol 2, Section A.3.
 	var mxcsr uint32
 	switch vmmType {
 	case vmmtypes.QEMU:
@@ -169,6 +170,14 @@ func BuildSaveArea(eip uint32, guestFeatures uint64, vcpuSig uint64, vmmType vmm
 		rdx = 0
 		mxcsr = 0
 		fcw = 0
+	case vmmtypes.GCE:
+		csFlags = 0x9b
+		ssFlags = 0x93
+		trFlags = 0x8b
+		gpat = 0x00070106 // GCE hypervisor overwrites default g_pat
+		rdx = 0x600
+		mxcsr = 0
+		fcw = 0x0
 	default:
 		return SevEsSaveArea{}, errors.New("unknown VMM type")
 	}
@@ -190,7 +199,7 @@ func BuildSaveArea(eip uint32, guestFeatures uint64, vcpuSig uint64, vmmType vmm
 		Dr6:         0xffff0ff0,
 		Rflags:      0x2,
 		Rip:         uint64(eip & 0xffff),
-		GPat:        0x7040600070406, // PAT MSR: See AMD APM Vol 2, Section A.3.
+		GPat:        gpat,
 		Rdx:         rdx,
 		SevFeatures: guestFeatures, // Documentation: https://github.com/virtee/sev-snp-measure/pull/32/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R125.
 		Xcr0:        0x1,


### PR DESCRIPTION
This is porting the functionality introduced with a previously merged [PR](https://github.com/virtee/sev-snp-measure/pull/56) on the [sev-snp-measure Python project](https://github.com/virtee/sev-snp-measure).

The same description applies here:
> Google Compute Engine (GCE) made Confidential VMs with SEV-SNP support generally available in June 2024 [1]. This patch adds support for deriving measurements for SEV-SNP guests running on GCE.
>
> GCE's measurement calculation differs from QEMU and EC2 implementations. The differences include:
> - Some metadata pages are loaded as a different page type
> - Initial CPU register state uses different values
>
> (Specifics interpreted from [2])
>
> This patch introduces a new VMM type: 'gce'.
>
> [1] https://cloud.google.com/blog/products/identity-security/rsa-snp-vm-more-confidential
> [2] https://github.com/google/gce-tcb-verifier

The new VMM type in this library is named: `VMMType.GCE`.

Additionally, I'll include some instructions that hopefully justify the changes included in the commit (similar to the ones included [in the previously referenced PR](https://github.com/virtee/sev-snp-measure/pull/56#issuecomment-3049268165), with minor adjustments):
- The [`SNP_SEC_MEM`](https://github.com/tianocore/edk2/blob/5090c39a59e308f6eedbbdc4c9004da9ab250a51/OvmfPkg/ResetVector/X64/OvmfSevMetadata.asm#L14-L15) pages are [loaded as `UNMEASURED` rather than `ZERO` type pages](https://github.com/google/gce-tcb-verifier/blob/74582c07899756043cf4ae98789bf5f670f1374a/sev/ld_from_ovmf.go#L98-L102).
- The 1st CPU register state is described [here](https://github.com/google/gce-tcb-verifier/blob/74582c07899756043cf4ae98789bf5f670f1374a/sev/ld_from_ovmf.go#L39-L62).
- The 2nd and following CPU register states [are equal and derived from the 1st, only overwriting the `cs` and `rip` registers](https://github.com/google/gce-tcb-verifier/blob/74582c07899756043cf4ae98789bf5f670f1374a/sev/ld_from_ovmf.go#L143-L159) with [values obtained from the SEV-ES reset block](https://github.com/google/gce-tcb-verifier/blob/74582c07899756043cf4ae98789bf5f670f1374a/ovmf/sev_data.go#L271-L277).
 
For additional verification, we can follow the [docs](https://cloud.google.com/confidential-computing/confidential-vm/docs/verify-firmware) to get the GCE UEFI binary, which summarizes as:
1. Fetch the SNP attestation report, and retrieve the measurement value, `$measurement`.
2. Get the serialized reference launch endorsement from the following Google Cloud Storage bucket.
```
gs://gce_tcb_integrity/ovmf_x64_csm/sevsnp/$measurement.binarypb
```
3. Parse and validate the launch endorsement signature using the [`gcetcbendorsement` tool](https://github.com/google/gce-tcb-verifier/tree/main/gcetcbendorsement/), or manually (see [docs](https://cloud.google.com/confidential-computing/confidential-vm/docs/verify-firmware)).
4. Retrieve the SHA-384 digest of the UEFI binary included in the launch endorsement, `$uefi_digest`.
5. Get the UEFI binary from the following Google Cloud Storage bucket.
```
gs://gce_tcb_integrity/ovmf_x64_csm/$uefi_digest.fd
```
6. Extract the `measurements` map from the message included in the launch endorsement, or create your own expected values JSON (`data.json`):
```json
[
  {
    "vcpus": "$vcpu_count",
    "measurement": "$measurement"
  }
]
```
with `$vcpu_count` as the number of guest vCPUs from the target confidential VM.

Finally, we can use the e2e test script to verify that the calculated measurement matches the expected one (`$measurement`), effectively linking the retrieved UEFI binary to the confidential VM launch, with the command:
```
go test --tags=e2e ./e2e --expected-values data.json --ovmf $uefi_digest.fd --guest-features 0x1 --vmm-type gce
```
 
Here are two valid Google Cloud Storage buckets holding two UEFI binaries used while I was testing:
```
gs://gce_tcb_integrity/ovmf_x64_csm/bfb625aa4119b890e273961a527ef0704c3dcb5e227a16aed2d3668f0df3da0c6c214f1fb318b44a820e75cd4fc05000.fd
gs://gce_tcb_integrity/ovmf_x64_csm/791a83d0a2623085ac2318bfff71122f24a5a0fe5a5cdd3bd2d678f9769510d782bff979caea1c01c99d78ae82537551.fd
```
and the attestation report binaries are available here:
```
n2d-standard-2 (2 vCPUs): https://drive.google.com/file/d/1PTTSIQsE8ak9THYAzEqwHZQF8w7W04V-/view?usp=sharing
n2d-standard-4 (4 vCPUs): https://drive.google.com/file/d/12-pOfup_6ni_cYasBgbrjrahyeNddp-o/view?usp=sharing
```
(Google Drive links will be valid until 2026-09-01)