### PR TITLE
Update EC2 VMSA rdx field from 0x0 to 0x600

### DIFF
--- a/guest/guest_test.go
+++ b/guest/guest_test.go
@@ -77,7 +77,7 @@ func TestLaunchDigestFromOVMF(t *testing.T) {
 			vcpuCount: 2,
 			vmmType:   vmmtypes.EC2,
 			// Created by running: ./sev-snp-measure.py --mode snp --vcpus 2 --ovmf ovmf_img_1.fd --vmm-type ec2 --snp-ovmf-hash a58211791a556a630a4319dc9e2ea96cc0e9784dd9f20a4fadf81b26c98d163fcdcb6703884bbbb80d7b1de45b3d84d0
-			expectedHash: "4c6e33087d08fa770259484dddbef367086a15c3e2cf10038dc97229d39c942671c2e22b300178f8de594a3f2fa59303",
+			expectedHash: "1c146f3083d66ad1648f842a62a65ad99b9fa4c8fe5b151b677f4923c1686004ce9ce3d1d9eda527f72bba78e6ceef67",
 		},
 		"success bin 2": {
 			ovmfPath: "testdata/ovmf_img_2.bin",
@@ -85,7 +85,7 @@ func TestLaunchDigestFromOVMF(t *testing.T) {
 			ovmfHash:     "2027a27bb9f7acfd280e4c7bd68a73973b94bf0756e5b282e004b9395f597b8d0eb4defa7d8f6549375aa4d2b146f0f3",
 			vcpuCount:    2,
 			vmmType:      vmmtypes.EC2,
-			expectedHash: "c2c84b9364fc9f0f54b04534768c860c6e0e386ad98b96e8b98eca46ac8971d05c531ba48373f054c880cfd1f4a0a84e",
+			expectedHash: "ef89452c1af43e29da35f8707836be26dbdb70654e46cd81368d7e130ab583018b70319e90b5890b63e2294eed84e63d",
 		},
 		"success bin 3": {
 			ovmfPath: "testdata/ovmf_img_1.bin",
@@ -142,13 +142,13 @@ func TestLaunchDigestFromMetadataWrapper(t *testing.T) {
 			apiObjectPath:  "testdata/ovmf_img_1.json",
 			vcpuCount:      2,
 			vmmType:        vmmtypes.EC2,
-			expectedDigest: "4c6e33087d08fa770259484dddbef367086a15c3e2cf10038dc97229d39c942671c2e22b300178f8de594a3f2fa59303",
+			expectedDigest: "1c146f3083d66ad1648f842a62a65ad99b9fa4c8fe5b151b677f4923c1686004ce9ce3d1d9eda527f72bba78e6ceef67",
 		},
 		"success bin 2": {
 			apiObjectPath:  "testdata/ovmf_img_2.json",
 			vcpuCount:      2,
 			vmmType:        vmmtypes.EC2,
-			expectedDigest: "c2c84b9364fc9f0f54b04534768c860c6e0e386ad98b96e8b98eca46ac8971d05c531ba48373f054c880cfd1f4a0a84e",
+			expectedDigest: "ef89452c1af43e29da35f8707836be26dbdb70654e46cd81368d7e130ab583018b70319e90b5890b63e2294eed84e63d",
 		},
 		"success bin 3": {
 			apiObjectPath:  "testdata/ovmf_img_1.json",

--- a/vmsa/vmsa.go
+++ b/vmsa/vmsa.go
@@ -167,7 +167,7 @@ func BuildSaveArea(eip uint32, guestFeatures uint64, vcpuSig uint64, vmmType vmm
 		}
 		ssFlags = 0x92
 		trFlags = 0x83
-		rdx = 0
+		rdx = 0x600
 		mxcsr = 0
 		fcw = 0
 	case vmmtypes.GCE:


### PR DESCRIPTION
Updates the EC2 VMSA rdx field from 0x0 to 0x600 to match the
current firmware behavior.

Context:
- https://github.com/aws/uefi/issues/19
- https://github.com/virtee/sev-snp-measure/pull/60